### PR TITLE
Make it generic

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,8 @@ module github.com/bep/lazycache
 go 1.18
 
 require (
+	github.com/bep/golang-lru/v2 v2.0.0-20221109181639-7772c2d8d424
 	github.com/frankban/quicktest v1.14.2
-	github.com/hashicorp/golang-lru v0.5.4
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -1,10 +1,10 @@
+github.com/bep/golang-lru/v2 v2.0.0-20221109181639-7772c2d8d424 h1:pCl5RyZx5P/AEKfWw0pNOLdDssKywh7O5i1vOWMYk6k=
+github.com/bep/golang-lru/v2 v2.0.0-20221109181639-7772c2d8d424/go.mod h1:VLsj4zCnENLusS8ylWozfleW5d8IN49A36vXR5PVoh4=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/frankban/quicktest v1.14.2 h1:SPb1KFFmM+ybpEjPUhCCkZOM5xlovT5UbrMvWnXyBns=
 github.com/frankban/quicktest v1.14.2/go.mod h1:mgiwOwqx65TmIk1wJ6Q7wvnVMocbUorkibMOrVTHZps=
 github.com/google/go-cmp v0.5.7 h1:81/ik6ipDQS2aGcBfIN5dHDB36BwrStyeAQquSYCV4o=
 github.com/google/go-cmp v0.5.7/go.mod h1:n+brtR0CgQNWTVd5ZUFpTBC8YFBDLK/h/bpaJ8/DtOE=
-github.com/hashicorp/golang-lru v0.5.4 h1:YDjusn29QI/Das2iO9M0BHnIbxPeyuCHsjMW+lJfyTc=
-github.com/hashicorp/golang-lru v0.5.4/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pretty v0.3.0 h1:WgNl7dwNpEZ6jJ9k1snq4pZsg7DOEN8hP9Xw0Tsjwk0=
 github.com/kr/pretty v0.3.0/go.mod h1:640gp4NfQd8pI5XOwp5fnNeVWj67G7CFk/SaSQn7NBk=

--- a/lazycache.go
+++ b/lazycache.go
@@ -3,66 +3,56 @@ package lazycache
 import (
 	"sync"
 
-	"github.com/hashicorp/golang-lru/simplelru"
+	"github.com/bep/golang-lru/v2/simplelru"
 )
 
-var _ = Entry(&delayedEntry{})
-
 // New creates a new Cache.
-func New(options CacheOptions) *Cache {
-	lru, err := simplelru.NewLRU(int(options.MaxEntries), nil)
+func New[K comparable, V any](options Options) *Cache[K, V] {
+	lru, err := simplelru.NewLRU[K, *valueWrapper[V]](int(options.MaxEntries), nil)
 	if err != nil {
 		panic(err)
 	}
-	c := &Cache{
+	c := &Cache[K, V]{
 		lru: lru,
 	}
 	return c
 }
 
-type CacheOptions struct {
+// Options holds the cache options.
+type Options struct {
 	// MaxEntries is the maximum number of entries that the cache should hold.
 	// Note that this can also be adjusted after the cache is created with Resize.
 	MaxEntries int
 }
 
-// Entry is the result of a cache lookup.
-// Any Err value is the error that was returned by the cache prime function. This error value is cached. TODO(bep) consider this.
-type Entry interface {
-	Value() any
-	Err() error
-}
-
-type Cache struct {
-	lru *simplelru.LRU
+// Cache is a thread-safe resizable LRU cache.
+type Cache[K comparable, V any] struct {
+	lru *simplelru.LRU[K, *valueWrapper[V]]
 	mu  sync.RWMutex
-}
 
-// Contains returns true if the given key is in the cache.
-func (c *Cache) Contains(key any) bool {
-	c.mu.RLock()
-	b := c.lru.Contains(key)
-	c.mu.RUnlock()
-	return b
+	zerov V
 }
 
 // Delete deletes the item with given key from the cache, returning if the
 // key was contained.
-func (c *Cache) Delete(key any) bool {
+func (c *Cache[K, V]) Delete(key K) bool {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	return c.lru.Remove(key)
 }
 
 // DeleteFunc deletes all entries for which the given function returns true.
-func (c *Cache) DeleteFunc(matches func(key any, item Entry) bool) int {
+func (c *Cache[K, V]) DeleteFunc(matches func(key K, item V) bool) int {
 	c.mu.RLock()
 	keys := c.lru.Keys()
 
-	var keysToDelete []any
+	var keysToDelete []K
 	for _, key := range keys {
-		v, _ := c.lru.Peek(key)
-		if matches(key, v.(Entry)) {
+		w, _ := c.lru.Peek(key)
+		if !w.wait().found {
+			continue
+		}
+		if matches(key, w.value) {
 			keysToDelete = append(keysToDelete, key)
 		}
 	}
@@ -80,65 +70,60 @@ func (c *Cache) DeleteFunc(matches func(key any, item Entry) bool) int {
 	return deleteCount
 }
 
-// Keys returns a slice of the keys in the cache, oldest first.
-func (c *Cache) Keys() []any {
-	c.mu.RLock()
-	defer c.mu.RUnlock()
-	return c.lru.Keys()
-}
-
-// Len returns the number of items in the cache.
-func (c *Cache) Len() int {
-	c.mu.RLock()
-	defer c.mu.RUnlock()
-	return c.lru.Len()
-}
-
 // Get returns the value associated with key.
-func (c *Cache) Get(key any) Entry {
+func (c *Cache[K, V]) Get(key K) (V, bool) {
 	c.mu.Lock()
-	v, ok := c.lru.Get(key)
+	w := c.get(key)
 	c.mu.Unlock()
-	if !ok {
-		return entry{}
+	if w == nil {
+		return c.zerov, false
 	}
-	return v.(Entry)
+	w.wait()
+	return w.value, w.found
 }
 
 // GetOrCreate returns the value associated with key, or creates it if it doesn't.
 // Note that create, the cache prime function, is called once and then not called again for a given key
 // unless the cache entry is evicted; it does not block other goroutines from calling GetOrCreate,
 // it is not called with the cache lock held.
-func (c *Cache) GetOrCreate(key any, create func(key any) (any, error)) Entry {
+func (c *Cache[K, V]) GetOrCreate(key K, create func(key K) (V, error)) (V, bool, error) {
 	c.mu.Lock()
-	v, ok := c.lru.Get(key)
-	if ok {
-		c.mu.Unlock()
-		return v.(Entry)
+	w := c.get(key)
+	if w != nil {
+		w.wait()
+		// if w.ready is set then w comes from a concurrent GetOrCreate call.
+		if w.found || w.ready != nil {
+			c.mu.Unlock()
+			return w.value, w.found, nil
+		}
 	}
 
-	var e = &delayedEntry{
-		done: make(chan struct{}),
+	w = &valueWrapper[V]{
+		ready: make(chan struct{}),
 	}
-	// Add the *delayedEntry early and release the lock.
-	// Calllers coming in getting the same cache entry will block on the done channel.
-	c.lru.Add(key, e)
+
+	// Concurrent access to the same key will see w, but needs to wait for w.ready
+	// to get the value.
+	c.lru.Add(key, w)
 	c.mu.Unlock()
 
 	// Create the  value with the lock released.
 	v, err := create(key)
+	w.err = err
+	w.value = v
+	w.found = err == nil
 
-	// e is a pointer, and these values will be available to other callers getting this cache entry,
-	// once the done channel is closed.
-	e.err = err
-	e.value = v
-	close(e.done)
+	close(w.ready)
 
-	return e
+	if err != nil {
+		c.Delete(key)
+		return c.zerov, false, err
+	}
+	return v, true, nil
 }
 
 // Resize changes the cache size and returns the number of entries evicted.
-func (c *Cache) Resize(size int) (evicted int) {
+func (c *Cache[K, V]) Resize(size int) (evicted int) {
 	c.mu.Lock()
 	evicted = c.lru.Resize(size)
 	c.mu.Unlock()
@@ -146,43 +131,57 @@ func (c *Cache) Resize(size int) (evicted int) {
 }
 
 // Set associates value with key.
-func (c *Cache) Set(key, value any) {
+func (c *Cache[K, V]) Set(key K, value V) {
 	c.mu.Lock()
-	if _, ok := value.(Entry); !ok {
-		value = entry{
-			value: value,
-		}
-	}
-	c.lru.Add(key, value)
+	c.lru.Add(key, &valueWrapper[V]{value: value, found: true})
 	c.mu.Unlock()
 }
 
-// delayedEntry holds a cache value or error that is not available until the done channel is closed.
-type delayedEntry struct {
-	done  chan struct{}
-	value any
+func (c *Cache[K, V]) get(key K) *valueWrapper[V] {
+	w, ok := c.lru.Get(key)
+	if !ok {
+		return nil
+	}
+	return w
+}
+
+// contains returns true if the given key is in the cache.
+// note that this wil also return true if the key is in the cache but the value is not yet ready.
+func (c *Cache[K, V]) contains(key K) bool {
+	c.mu.RLock()
+	b := c.lru.Contains(key)
+	c.mu.RUnlock()
+	return b
+}
+
+// keys returns a slice of the keys in the cache, oldest first.
+// note that this wil also include keys that are not yet ready.
+func (c *Cache[K, V]) keys() []K {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.lru.Keys()
+}
+
+// len returns the number of items in the cache.
+// note that this wil also include values that are not yet ready.
+func (c *Cache[K, V]) len() int {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.lru.Len()
+}
+
+// valueWrapper holds a cache value that is not available unless the done channel is nil or closed.
+// This construct makes more sense if you look at the code in GetOrCreate.
+type valueWrapper[V any] struct {
+	value V
+	found bool
 	err   error
+	ready chan struct{}
 }
 
-func (r *delayedEntry) Value() any {
-	<-r.done
-	return r.value
-}
-
-func (r *delayedEntry) Err() error {
-	<-r.done
-	return r.err
-}
-
-type entry struct {
-	value any
-	err   error
-}
-
-func (r entry) Value() any {
-	return r.value
-}
-
-func (r entry) Err() error {
-	return r.err
+func (w *valueWrapper[V]) wait() *valueWrapper[V] {
+	if w.ready != nil {
+		<-w.ready
+	}
+	return w
 }


### PR DESCRIPTION
Which makes it more pleasant to use and, in general, faster:

```bash
name                 old time/op    new time/op    delta
GetOrCreate/Real-4      276µs ±82%     351µs ±43%     ~     (p=0.343 n=4+4)
CacheSerial/Set-4       176ns ± 0%     120ns ± 0%  -31.96%  (p=0.029 n=4+4)
CacheSerial/Get-4      27.1ns ± 2%    20.7ns ± 1%  -23.62%  (p=0.029 n=4+4)
CacheParallel/Set-4     272ns ± 1%     233ns ± 0%  -14.05%  (p=0.029 n=4+4)
CacheParallel/Get-4     149ns ± 1%     144ns ± 2%   -3.33%  (p=0.029 n=4+4)

name                 old alloc/op   new alloc/op   delta
GetOrCreate/Real-4      37.5B ± 9%     26.5B ± 9%  -29.33%  (p=0.029 n=4+4)
CacheSerial/Set-4        128B ± 0%      104B ± 0%  -18.75%  (p=0.029 n=4+4)
CacheSerial/Get-4       0.00B          0.00B          ~     (all equal)
CacheParallel/Set-4      128B ± 0%      104B ± 0%  -18.75%  (p=0.029 n=4+4)
CacheParallel/Get-4     0.00B          0.00B          ~     (all equal)

name                 old allocs/op  new allocs/op  delta
GetOrCreate/Real-4       1.50 ±33%      1.00 ± 0%     ~     (p=0.429 n=4+4)
CacheSerial/Set-4        4.00 ± 0%      2.00 ± 0%  -50.00%  (p=0.029 n=4+4)
CacheSerial/Get-4        0.00           0.00          ~     (all equal)
CacheParallel/Set-4      4.00 ± 0%      2.00 ± 0%  -50.00%  (p=0.029 n=4+4)
CacheParallel/Get-4      0.00           0.00          ~     (all equal)
```

Note that this uses a temporary fork of https://github.com/hashicorp/golang-lru/pull/111 ... which, cross fingers, will get merged soon.