### PR TITLE
Fix potential deadlock with nested GetOrCreate calls

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,9 +18,6 @@ jobs:
     - name: Install staticcheck
       run: go install honnef.co/go/tools/cmd/staticcheck@latest
       shell: bash
-    - name: Install golint
-      run: go install golang.org/x/lint/golint@latest
-      shell: bash
     - name: Update PATH
       run: echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
       shell: bash
@@ -34,8 +31,6 @@ jobs:
       run: go vet ./...
     - name: Staticcheck
       run: staticcheck ./...
-    - name: Lint
-      run: golint ./...
     - name: Test
       run: go test -race ./... -coverpkg=./... -coverprofile=coverage.txt -covermode=atomic
     - name: Upload coverage

--- a/lazycache.go
+++ b/lazycache.go
@@ -88,14 +88,14 @@ func (c *Cache[K, V]) Get(key K) (V, bool) {
 // it is not called with the cache lock held.
 // Note that any error returned by create will be returned by GetOrCreate and repeated calls with the same key will
 // receive the same error.
-func (c *Cache[K, V]) GetOrCreate(key K, create func(key K) (V, error)) (V, bool, error) {
+func (c *Cache[K, V]) GetOrCreate(key K, create func(key K) (V, error)) (V, error) {
 	c.mu.Lock()
 	w := c.get(key)
 	if w != nil {
 		c.mu.Unlock()
 		w.wait()
 		// If w.ready is nil, we will repeat any error from the create function to concurrent callers.
-		return w.value, w.found, w.err
+		return w.value, w.err
 	}
 
 	w = &valueWrapper[V]{
@@ -117,9 +117,9 @@ func (c *Cache[K, V]) GetOrCreate(key K, create func(key K) (V, error)) (V, bool
 
 	if err != nil {
 		c.Delete(key)
-		return c.zerov, false, err
+		return c.zerov, err
 	}
-	return v, true, nil
+	return v, nil
 }
 
 // Resize changes the cache size and returns the number of entries evicted.


### PR DESCRIPTION
The new revived lock logic is also faster:

```
name               old time/op    new time/op    delta
NewGetOrCreate-10     301µs ± 0%     101µs ± 0%  -66.59%  (p=0.004 n=6+5)

name               old alloc/op   new alloc/op   delta
NewGetOrCreate-10     19.3B ± 3%     19.7B ± 3%     ~     (p=0.567 n=6+6)

name               old allocs/op  new allocs/op  delta
NewGetOrCreate-10      0.00           0.00          ~     (all equal)
```
